### PR TITLE
Fixed rapid network acquisition

### DIFF
--- a/smtc_modem_core/device_management/modem_context.c
+++ b/smtc_modem_core/device_management/modem_context.c
@@ -668,7 +668,11 @@ void modem_supervisor_add_task_join( void )
     SMTC_MODEM_HAL_TRACE_WARNING( "BYPASS JOIN DUTY CYCLE activated\n" );
     task_join.time_to_execute_s += current_time_s;
 #else
-    if( lorawan_api_modem_certification_is_enabled( ) == false )
+    if( !lorawan_api_is_dtc_supported() )
+    {
+        task_join.time_to_execute_s += current_time_s;
+    }
+    else if( lorawan_api_modem_certification_is_enabled() == false )
     {
         // current time is already taken in count in lr1mac time computation
         task_join.time_to_execute_s += lorawan_api_next_join_time_second_get( );

--- a/smtc_modem_core/lorawan_api/lorawan_api.c
+++ b/smtc_modem_core/lorawan_api/lorawan_api.c
@@ -226,6 +226,11 @@ void lorawan_api_class_b_d2d_tx_event_callback( smtc_class_b_d2d_t* class_b_d2d_
 }
 #endif
 
+bool lorawan_api_is_dtc_supported(void)
+{
+    return smtc_real_is_dtc_supported( lr1_mac_obj.real );
+}
+
 smtc_real_region_types_t lorawan_api_get_region( void )
 {
     return lr1mac_core_get_region( &lr1_mac_obj );

--- a/smtc_modem_core/lorawan_api/lorawan_api.h
+++ b/smtc_modem_core/lorawan_api/lorawan_api.h
@@ -100,6 +100,13 @@ typedef enum lorawan_multicast_rc_e
 void lorawan_api_init( radio_planner_t* rp );
 
 /**
+ * @brief Get duty cycle supported for current region
+ *
+ * @return  bool true == yes
+ */
+bool lorawan_api_is_dtc_supported( void );
+
+/**
  * @brief Get the current LoRaWAN region
  *
  * @return smtc_real_region_types_t Current region

--- a/smtc_modem_core/lr1mac/src/lr1mac_core.c
+++ b/smtc_modem_core/lr1mac/src/lr1mac_core.c
@@ -184,7 +184,7 @@ lr1mac_states_t lr1mac_core_process( lr1_stack_mac_t* lr1_mac_obj )
     rp_hook_get_id( lr1_mac_obj->rp, ( void* ) ( ( lr1_mac_obj ) ), &myhook_id );
 
 #if !defined( TEST_BYPASS_JOIN_DUTY_CYCLE )
-    if( lr1mac_core_certification_get( lr1_mac_obj ) == false )
+    if( smtc_real_is_dtc_supported( lr1_mac_obj->real ) && lr1mac_core_certification_get( lr1_mac_obj ) == false )
     {
         if( ( lr1_mac_joined_status_get( lr1_mac_obj ) == JOINING ) &&
             ( ( int32_t )( lr1_mac_obj->next_time_to_join_seconds - smtc_modem_hal_get_time_in_s( ) ) > 0 ) )


### PR DESCRIPTION
Dear maintainers.

This PR is accompanying the Lpd Community case: 65290

> The LoRaWAN Basics modem supports the US915 rapid network acquisition as described by the regional parameters (on join random selecting one channel from the first band, on no response randomly selecting a channel from the second band etc). This is very important for US915 networks that have only an 8 channel network.
> 
> Although the algorithm works correctly, the timing is not correct. Some regions are duty cycle limited (e.g. EU868) and others are dwell-time limited (e.g. US915). But it seems that the US915 join process use duty cycle limitation as well. This leads into a very slow join process.

We would be happy to add information if needed. Let me know.