### PR TITLE
Add sanity check to sx126x driver when handling retention list

### DIFF
--- a/lbm_lib/smtc_modem_core/radio_drivers/sx126x_driver/src/sx126x.c
+++ b/lbm_lib/smtc_modem_core/radio_drivers/sx126x_driver/src/sx126x.c
@@ -1413,8 +1413,15 @@ sx126x_status_t sx126x_add_registers_to_retention_list( const void* context, con
 
     if( status == SX126X_STATUS_OK )
     {
-        const uint8_t initial_nb_of_registers = buffer[0];
-        uint8_t*      register_list           = &buffer[1];
+        uint8_t initial_nb_of_registers = buffer[0];
+        uint8_t*      register_list     = &buffer[1];
+
+        // sanity check - in case invalid value read -> set to zero
+        if(initial_nb_of_registers > SX126X_MAX_NB_REG_IN_RETENTION)
+        {
+            initial_nb_of_registers = 0;
+            buffer[0] = 0;
+        }
 
         for( uint8_t index = 0; index < register_nb; index++ )
         {


### PR DESCRIPTION
If an invalid value is read and present in buffer[0], then :

```
if( register_addr[index] == ( ( uint16_t ) register_list[2 * i] << 8 ) + register_list[2 * i + 1] )
```
here happens reading out of bounds of the buffer[] array. 
Even more - the buffer[0] is made on stack:
```
uint8_t buffer[9] = {0};
```
Which is ok, but in combination with the bug above and with the fact, that the stack is in 99.9% cases placed at the end of the RAM, this will cause reading values in an address which is out of bound of RAM/SRAM and therefore a hardfault/memfault/crash will be generated.

The issue can happen and an invalid value can be read out of SX1261 due to power variation, EMC, etc.. and happened to me, when stressing and testing my hardware and generating variations of power of SX1261 close to the allowed voltage area.

This should not happen during normal operation, but it CAN happen - and it is not ok to take down the whole microcontroller system in that case.
